### PR TITLE
feat: Add argument environment variables support to MCP templates

### DIFF
--- a/crates/mcp-orchestrator-front/src/components/copy_config_dialog.rs
+++ b/crates/mcp-orchestrator-front/src/components/copy_config_dialog.rs
@@ -1,0 +1,87 @@
+use yew::prelude::*;
+use web_sys::window;
+
+#[derive(Properties, PartialEq)]
+pub struct CopyConfigDialogProps {
+    pub show: bool,
+    pub config_json: String,
+    pub on_close: Callback<()>,
+}
+
+#[function_component(CopyConfigDialog)]
+pub fn copy_config_dialog(props: &CopyConfigDialogProps) -> Html {
+    let copy_status = use_state(|| String::new());
+
+    let on_copy = {
+        let config_json = props.config_json.clone();
+        let copy_status = copy_status.clone();
+        Callback::from(move |_| {
+            if let Some(window) = window() {
+                let navigator = window.navigator();
+                let clipboard = navigator.clipboard();
+                let config = config_json.clone();
+                let status = copy_status.clone();
+                wasm_bindgen_futures::spawn_local(async move {
+                    match wasm_bindgen_futures::JsFuture::from(clipboard.write_text(&config))
+                        .await
+                    {
+                        Ok(_) => status.set("Copied to clipboard!".to_string()),
+                        Err(_) => status.set("Failed to copy".to_string()),
+                    }
+                });
+            }
+        })
+    };
+
+    let on_backdrop_click = {
+        let on_close = props.on_close.clone();
+        Callback::from(move |_| {
+            on_close.emit(());
+        })
+    };
+
+    let on_close_click = {
+        let on_close = props.on_close.clone();
+        Callback::from(move |_| {
+            on_close.emit(());
+        })
+    };
+
+    if !props.show {
+        return html! {};
+    }
+
+    html! {
+        <div class="modal-overlay" onclick={on_backdrop_click}>
+            <div class="modal-content" style="max-width: 600px;" onclick={|e: MouseEvent| e.stop_propagation()}>
+                <div class="modal-header">
+                    <h2>{ "MCP Server Configuration" }</h2>
+                    <button class="close-button" onclick={on_close_click.clone()}>{ "×" }</button>
+                </div>
+                <div class="modal-body">
+                    <p style="margin-bottom: 1rem;">{ "Copy this configuration to your MCP client settings:" }</p>
+                    <pre style="background: #1e1e1e; color: #d4d4d4; padding: 1rem; border-radius: 4px; overflow-x: auto; font-size: 0.9rem;">
+                        <code>{ &props.config_json }</code>
+                    </pre>
+                    { if !copy_status.is_empty() {
+                        html! {
+                            <div style="margin-top: 0.5rem; color: green; font-weight: bold;">
+                                { &*copy_status }
+                            </div>
+                        }
+                    } else {
+                        html! {}
+                    }}
+                </div>
+                <div class="modal-footer">
+                    <button class="btn-primary" onclick={on_copy}>
+                        { "📋 Copy to Clipboard" }
+                    </button>
+                    <button class="btn-secondary" onclick={on_close_click}>
+                        { "Close" }
+                    </button>
+                </div>
+            </div>
+        </div>
+    }
+}

--- a/crates/mcp-orchestrator-front/src/components/mod.rs
+++ b/crates/mcp-orchestrator-front/src/components/mod.rs
@@ -1,4 +1,5 @@
 pub mod confirm_dialog;
+pub mod copy_config_dialog;
 pub mod error_message;
 pub mod form_field;
 pub mod layout;
@@ -11,6 +12,7 @@ pub mod sidebar;
 pub mod user_menu;
 
 pub use confirm_dialog::*;
+pub use copy_config_dialog::*;
 pub use error_message::*;
 pub use form_field::*;
 pub use layout::*;

--- a/crates/mcp-orchestrator-front/src/models/template.rs
+++ b/crates/mcp-orchestrator-front/src/models/template.rs
@@ -10,6 +10,7 @@ pub struct Template {
     pub command: Vec<String>,
     pub args: Vec<String>,
     pub envs: HashMap<String, String>,
+    pub arg_envs: HashMap<String, String>,
     pub secret_envs: Vec<String>,
     pub resource_limit_name: Option<String>,
     pub authorization_name: Option<String>,
@@ -27,6 +28,7 @@ impl From<McpTemplateResponse> for Template {
             command: response.command,
             args: response.args,
             envs: response.envs,
+            arg_envs: response.arg_envs,
             secret_envs: response.secret_envs,
             resource_limit_name: if response.resource_limit_name.is_empty() {
                 None
@@ -52,6 +54,7 @@ pub struct TemplateFormData {
     pub command: Vec<String>,
     pub args: Vec<String>,
     pub envs: HashMap<String, String>,
+    pub arg_envs: HashMap<String, String>,
     pub secret_envs: Vec<String>,
     pub resource_limit_name: Option<String>,
     pub authorization_name: Option<String>,
@@ -78,6 +81,7 @@ impl TemplateFormData {
             command: self.command,
             args: self.args,
             envs: self.envs,
+            arg_envs: self.arg_envs,
             secret_envs: filtered_secret_envs,
             resource_limit_name: self.resource_limit_name.unwrap_or_default(),
             authorization_name: self.authorization_name,

--- a/crates/mcp-orchestrator-front/src/pages/templates/list.rs
+++ b/crates/mcp-orchestrator-front/src/pages/templates/list.rs
@@ -1,5 +1,6 @@
 use crate::api::APICaller;
-use crate::components::{ErrorMessage, Loading, NamespaceSelector};
+use crate::components::{CopyConfigDialog, ErrorMessage, Loading, NamespaceSelector};
+use crate::models::authorization::Authorization;
 use crate::models::state::AuthState;
 use crate::models::template::Template;
 use crate::models::SessionState;
@@ -24,6 +25,9 @@ pub fn template_list() -> Html {
         .selected_namespace
         .clone()
         .unwrap_or_else(|| "default".to_string());
+    
+    let show_copy_dialog = use_state(|| false);
+    let copy_config = use_state(|| String::new());
 
     {
         let load_state = load_state.clone();
@@ -40,6 +44,114 @@ pub fn template_list() -> Html {
         });
     }
 
+    let generate_mcp_config = |template: &Template, authorization: &Option<Authorization>| -> String {
+        let current_origin = web_sys::window()
+            .and_then(|w| w.location().origin().ok())
+            .unwrap_or_else(|| "http://localhost:8080".to_string());
+        
+        let url = format!("{}/mcp/{}/{}", current_origin, template.namespace, template.name);
+        
+        let has_arg_envs = !template.arg_envs.is_empty();
+        let has_k8s_sa_auth = authorization
+            .as_ref()
+            .map(|auth| auth.auth_type == 1) // KUBERNETES_SERVICE_ACCOUNT = 1
+            .unwrap_or(false);
+        
+        let mut headers = Vec::new();
+        
+        // Add arg-env headers
+        if has_arg_envs {
+            for (key, value) in &template.arg_envs {
+                let type_example = if value.contains("?") || value.ends_with("?") {
+                    "\"value\" or null"
+                } else {
+                    "\"value\""
+                };
+                headers.push(format!("    \"arg-{}\": {}", key, type_example));
+            }
+        }
+        
+        // Add Authorization header if K8s SA
+        if has_k8s_sa_auth {
+            headers.push(format!("    \"Authorization\": \"Bearer <token>\""));
+        }
+        
+        if !headers.is_empty() {
+            format!(
+r#"{{
+  "mcpServers": {{
+    "{}": {{
+      "type": "remote",
+      "url": "{}",
+      "headers": {{
+{}
+      }}
+    }}
+  }}
+}}"#,
+                template.name,
+                url,
+                headers.join(",\n")
+            )
+        } else {
+            format!(
+r#"{{
+  "mcpServers": {{
+    "{}": {{
+      "type": "remote",
+      "url": "{}"
+    }}
+  }}
+}}"#,
+                template.name,
+                url
+            )
+        }
+    };
+
+    let on_copy_config = {
+        let show_copy_dialog = show_copy_dialog.clone();
+        let copy_config = copy_config.clone();
+        let auth_state = auth_state.clone();
+        move |template: Template| {
+            let show_copy_dialog = show_copy_dialog.clone();
+            let copy_config = copy_config.clone();
+            let auth_state = auth_state.clone();
+            
+            wasm_bindgen_futures::spawn_local(async move {
+                let api = APICaller::new(auth_state.access_token.clone());
+                
+                // Load authorization if specified
+                let authorization = if let Some(auth_name) = &template.authorization_name {
+                    if !auth_name.is_empty() {
+                        match api.get_authorization(template.namespace.clone(), auth_name.clone()).await {
+                            Ok(auth) => Some(auth),
+                            Err(e) => {
+                                web_sys::console::error_1(&format!("Failed to load authorization: {}", e).into());
+                                None
+                            }
+                        }
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                };
+                
+                let config = generate_mcp_config(&template, &authorization);
+                copy_config.set(config);
+                show_copy_dialog.set(true);
+            });
+        }
+    };
+
+    let on_close_dialog = {
+        let show_copy_dialog = show_copy_dialog.clone();
+        Callback::from(move |_| {
+            show_copy_dialog.set(false);
+        })
+    };
+
     html! {
         <div class="container">
             <NamespaceSelector />
@@ -50,6 +162,12 @@ pub fn template_list() -> Html {
                     <button class="btn-primary">{ "Create Template" }</button>
                 </Link<Route>>
             </div>
+
+            <CopyConfigDialog 
+                show={*show_copy_dialog}
+                config_json={(*copy_config).clone()}
+                on_close={on_close_dialog}
+            />
 
             { match &*load_state {
                 LoadState::Loading => html! { <Loading /> },
@@ -68,6 +186,14 @@ pub fn template_list() -> Html {
                                     { for templates.iter().map(|template| {
                                         let namespace = template.namespace.clone();
                                         let name = template.name.clone();
+                                        let template_for_copy = template.clone();
+                                        let on_copy_click = {
+                                            let on_copy_config = on_copy_config.clone();
+                                            Callback::from(move |_| {
+                                                on_copy_config(template_for_copy.clone());
+                                            })
+                                        };
+                                        
                                         html! {
                                             <div class="card" key={format!("{}/{}", namespace, name)}>
                                                 <div class="card-header">
@@ -95,6 +221,9 @@ pub fn template_list() -> Html {
                                                     </div>
                                                 </div>
                                                 <div class="card-footer">
+                                                    <button class="btn-primary" onclick={on_copy_click} title="Copy MCP configuration">
+                                                        { "📋 Copy Config" }
+                                                    </button>
                                                     <Link<Route> to={Route::TemplateDetail { namespace: namespace.clone(), name: name.clone() }}>
                                                         <button class="btn-secondary">{ "View Details" }</button>
                                                     </Link<Route>>

--- a/crates/mcp-orchestrator-front/src/utils/validation.rs
+++ b/crates/mcp-orchestrator-front/src/utils/validation.rs
@@ -72,3 +72,104 @@ pub fn validate_memory(memory: &str) -> Option<String> {
 
     Some("Invalid memory format (e.g., '512Mi', '4Gi')".to_string())
 }
+
+pub fn validate_arg_env_key(key: &str) -> Option<String> {
+    if key.is_empty() {
+        return Some("Key is required".to_string());
+    }
+    
+    // ^[a-z][a-z0-9-]*$ - 소문자로 시작해야 함
+    let first_char = key.chars().next().unwrap();
+    if !first_char.is_ascii_lowercase() {
+        return Some("Key must start with a lowercase letter (a-z)".to_string());
+    }
+    
+    // 나머지는 소문자, 숫자, 하이픈만 허용
+    if !key.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-') {
+        return Some("Key can only contain lowercase letters (a-z), digits (0-9), and hyphens (-)".to_string());
+    }
+    
+    None
+}
+
+pub fn validate_arg_env_value(value: &str) -> Option<String> {
+    if value.is_empty() {
+        return Some("Value is required".to_string());
+    }
+    
+    // ^((?<ENV_NAME>[A-Za-z0-9_-]+)\s*:\s*)?(?<TYPENAME>[a-z][a-z0-9-]*\??)$
+    
+    // {ENV_NAME}: {TYPE} 형태인지 확인
+    if let Some((env_name, type_part)) = value.split_once(':') {
+        let env_name = env_name.trim();
+        let type_part = type_part.trim();
+        
+        // 환경변수명 검증: [A-Za-z0-9_-]+
+        if env_name.is_empty() {
+            return Some("Environment variable name is required before ':'".to_string());
+        }
+        
+        if !env_name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
+            return Some("Environment variable name can only contain letters (A-Z, a-z), digits (0-9), underscores (_), and hyphens (-)".to_string());
+        }
+        
+        // 타입 검증: ^[a-z][a-z0-9-]*\??$ (끝에 선택적으로 ? 허용)
+        if type_part.is_empty() {
+            return Some("Type is required after ':'".to_string());
+        }
+        
+        let first_char = type_part.chars().next().unwrap();
+        if !first_char.is_ascii_lowercase() {
+            return Some("Type must start with a lowercase letter".to_string());
+        }
+        
+        if !type_part.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '?') {
+            return Some("Type can only contain lowercase letters, digits, hyphens, and optional '?' at the end".to_string());
+        }
+        
+        // ? 는 끝에만 올 수 있고 최대 1개만 허용
+        let question_count = type_part.chars().filter(|&c| c == '?').count();
+        if question_count > 1 {
+            return Some("Type can only have one '?' at the end".to_string());
+        }
+        if question_count == 1 && !type_part.ends_with('?') {
+            return Some("'?' can only appear at the end of the type".to_string());
+        }
+        
+        return None;
+    }
+    
+    // {TYPE} 형태만 있는 경우: ^[a-z][a-z0-9-]*\??$ (끝에 선택적으로 ? 허용)
+    let first_char = value.chars().next().unwrap();
+    if !first_char.is_ascii_lowercase() {
+        return Some("Type must start with a lowercase letter".to_string());
+    }
+    
+    if !value.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '?') {
+        return Some("Type can only contain lowercase letters, digits, hyphens, and optional '?' at the end".to_string());
+    }
+    
+    // ? 는 끝에만 올 수 있고 최대 1개만 허용
+    let question_count = value.chars().filter(|&c| c == '?').count();
+    if question_count > 1 {
+        return Some("Type can only have one '?' at the end".to_string());
+    }
+    if question_count == 1 && !value.ends_with('?') {
+        return Some("'?' can only appear at the end of the type".to_string());
+    }
+    
+    None
+}
+
+pub fn validate_arg_env_name(env_name: &str) -> Option<String> {
+    if env_name.is_empty() {
+        return None; // 선택적이므로 빈 값 허용
+    }
+    
+    // [A-Za-z0-9_-]+
+    if !env_name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
+        return Some("Environment variable name can only contain letters (A-Z, a-z), digits (0-9), underscores (_), and hyphens (-)".to_string());
+    }
+    
+    None
+}

--- a/crates/mcp-orchestrator-front/styles.css
+++ b/crates/mcp-orchestrator-front/styles.css
@@ -903,6 +903,40 @@ button:disabled,
   justify-content: flex-end;
 }
 
+.modal-body {
+  margin: 1.5rem 0;
+}
+
+.modal-footer {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.close-button {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  transition: all 0.2s ease;
+}
+
+.close-button:hover {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .navbar {

--- a/crates/mcp-orchestrator/src/error.rs
+++ b/crates/mcp-orchestrator/src/error.rs
@@ -19,14 +19,13 @@ pub enum AppError {
     InvalidLabelKey(String),
 
     #[error("Invalid label value: {value} for key: {key}")]
-    InvalidLabelValue{
-        value: String,
-        key: String,
-    },
-
+    InvalidLabelValue { value: String, key: String },
 
     #[error("Invalid input: {0}")]
     InvalidInput(String),
+
+    #[error("Invalid arg env: {0}")]
+    InvalidArgEnv(String),
 
     #[error("JSON Patch error: {0}")]
     Patch(#[from] json_patch::PatchError),
@@ -42,6 +41,7 @@ impl IntoResponse for AppError {
             AppError::InvalidLabelKey(msg) => (axum::http::StatusCode::BAD_REQUEST, msg.clone()),
             AppError::InvalidInput(msg) => (axum::http::StatusCode::BAD_REQUEST, msg.clone()),
             AppError::ProtectedNamespace(msg) => (axum::http::StatusCode::FORBIDDEN, msg.clone()),
+            AppError::InvalidArgEnv(msg) => (axum::http::StatusCode::BAD_REQUEST, msg.clone()),
             _ => (
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR,
                 self.to_string(),

--- a/crates/mcp-orchestrator/src/grpc/mcp_template.rs
+++ b/crates/mcp-orchestrator/src/grpc/mcp_template.rs
@@ -21,6 +21,7 @@ fn from(rl: McpTemplateData) -> McpTemplateResponse {
         command: rl.command,
         args: rl.args,
         envs: rl.envs,
+        arg_envs: rl.arg_envs,
         secret_envs: rl.secret_envs,
         resource_limit_name: rl.resource_limit_name,
         authorization_name: rl.authorization_name,
@@ -49,6 +50,7 @@ pub async fn create_mcp_template(
                 command: req.command,
                 args: req.args,
                 envs: req.envs,
+                arg_envs: req.arg_envs,
                 secret_envs: req.secret_envs,
                 resource_limit_name: req.resource_limit_name,
                 authorization_name: req.authorization_name.unwrap_or("anonymous".to_string()),
@@ -57,7 +59,10 @@ pub async fn create_mcp_template(
             },
         )
         .await
-        .map_err(|e| Status::internal(format!("Failed to create MCP template: {}", e)))?;
+        .map_err(|e| {
+            tracing::error!("Failed to create MCP template: {}", e);
+            Status::internal(format!("Failed to create MCP template: {}", e))
+        })?;
 
     Ok(Response::new(from(mt)))
 }

--- a/crates/mcp-orchestrator/src/podmcp/manager.rs
+++ b/crates/mcp-orchestrator/src/podmcp/manager.rs
@@ -108,9 +108,13 @@ pub struct PodMcpRequest {
 }
 
 impl PodMcpSessionManager {
-    pub async fn create_session(&self, req: PodMcpRequest) -> Result<SessionId, McpPodError> {
+    pub async fn create_session(
+        &self,
+        req: PodMcpRequest,
+        args: HashMap<String, String>,
+    ) -> Result<SessionId, McpPodError> {
         let id = session_id();
-        let (pod, auth) = self.0.template.to_pod(&id, &self.1.client).await?;
+        let (pod, auth) = self.0.template.to_pod(&id, &self.1.client, args).await?;
         //
         self.assert_auth_check(&auth, &req).await?;
         //

--- a/crates/mcp-orchestrator/src/storage/store_mcp_template.rs
+++ b/crates/mcp-orchestrator/src/storage/store_mcp_template.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::LazyLock,
+};
 
 use chrono::{DateTime, Duration, Utc};
 use k8s_openapi::api::core::v1::{ConfigMap, Container, EnvVar, Pod, PodSpec};
@@ -34,6 +37,14 @@ use crate::{
     },
 };
 
+static LAZY_ARG_ENV_KEY: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"^[a-z][a-z0-9-]*$").unwrap());
+
+static LAZY_ARG_ENV_VALUE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"^((?<ENV_NAME>[A-Za-z0-9_-]+)\s*:\s*)?(?<TYPENAME>[a-z][a-z0-9-]*\??)$")
+        .unwrap()
+});
+
 const FINALIZER_NAME: &str = "mcp-orchestrator.egoavara.net/mcp-template";
 const DATA_IMAGE: &str = "image";
 const DATA_COMMAND: &str = "command";
@@ -47,6 +58,11 @@ const DATA_SECRET_MOUNTS: &str = "secret_mounts";
 fn data_env_var(name: &str) -> String {
     format!("env_{}", name)
 }
+
+fn data_arg_env_var(name: &str) -> String {
+    format!("arg_env_{}", name)
+}
+
 fn parse_env_var(key: &str) -> Option<String> {
     if key.starts_with("env_") {
         let key = key.trim_start_matches("env_");
@@ -54,6 +70,40 @@ fn parse_env_var(key: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+fn parse_arg_env_var(key: &str) -> Option<String> {
+    if key.starts_with("arg_env_") {
+        let key = key.trim_start_matches("arg_env_");
+        Some(key.to_string())
+    } else {
+        None
+    }
+}
+
+fn assert_valid_arg_env_key(key: &str) -> Result<(), AppError> {
+    if LAZY_ARG_ENV_KEY.is_match(key) {
+        Ok(())
+    } else {
+        Err(AppError::InvalidInput(format!(
+            "Invalid arg_env key: {}",
+            key
+        )))
+    }
+}
+
+fn assert_valid_arg_env_value(key: &str, value: &str) -> Result<(String, String), AppError> {
+    LAZY_ARG_ENV_VALUE
+        .captures(value)
+        .and_then(|caps| {
+            let typename = caps.name("TYPENAME")?.as_str().to_string();
+            let env_name = caps
+                .name("ENV_NAME")
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_else(|| key.to_string());
+            Some((env_name, typename))
+        })
+        .ok_or_else(|| AppError::InvalidArgEnv(value.to_string()))
 }
 
 pub struct McpTemplateData {
@@ -65,6 +115,7 @@ pub struct McpTemplateData {
     pub command: Vec<String>,
     pub args: Vec<String>,
     pub envs: HashMap<String, String>,
+    pub arg_envs: HashMap<String, String>,
     pub secret_envs: Vec<String>,
     pub resource_limit_name: String,
     pub authorization_name: String,
@@ -86,12 +137,15 @@ impl McpTemplateData {
         let secret_mounts: Vec<v1::SecretMount> = parse_data_elem(&cm.data, DATA_SECRET_MOUNTS)?;
 
         let mut envs: HashMap<String, String> = HashMap::new();
+        let mut arg_envs: HashMap<String, String> = HashMap::new();
         if let Some(data) = &cm.data {
             for (key, value) in data.iter() {
-                let Some(key) = parse_env_var(key) else {
-                    continue;
-                };
-                envs.insert(key, value.clone());
+                if let Some(key) = parse_env_var(key) {
+                    envs.insert(key, value.clone());
+                }
+                if let Some(key) = parse_arg_env_var(key) {
+                    arg_envs.insert(key, value.clone());
+                }
             }
         }
 
@@ -115,6 +169,7 @@ impl McpTemplateData {
             command,
             args,
             envs,
+            arg_envs,
             secret_envs,
             resource_limit_name,
             authorization_name,
@@ -182,6 +237,7 @@ impl McpTemplateData {
         &self,
         session_id: &SessionId,
         client: &KubeStore,
+        args: HashMap<String, String>,
     ) -> Result<(Pod, AuthorizationData), AppError> {
         let resource_limit_store = client.resource_limits();
         let _store_auth = client.authorization(Some(self.namespace.clone()));
@@ -215,6 +271,7 @@ impl McpTemplateData {
                 },
             );
         }
+
         for secret_name in self.secret_envs.iter() {
             let secret = secrets.get(secret_name).ok_or_else(|| {
                 AppError::Internal(format!(
@@ -239,6 +296,35 @@ impl McpTemplateData {
                     },
                 );
             }
+        }
+
+        for (arg_key, arg_val) in self.arg_envs.iter() {
+            let (env_name, env_type) = assert_valid_arg_env_value(arg_key, arg_val)?;
+            match env_type.as_str() {
+                "string" => {
+                    if !args.contains_key(arg_key.as_str()) {
+                        return Err(AppError::InvalidArgEnv(format!(
+                            "Argument {} not provided for McpTemplate {}/{}",
+                            arg_key, self.namespace, self.name
+                        )));
+                    }
+                }
+                "string?" => {}
+                _ => {
+                    return Err(AppError::InvalidArgEnv(arg_val.clone()));
+                }
+            }
+            let Some(real_val) = args.get(arg_key).cloned() else {
+                continue;
+            };
+            envs.insert(
+                env_name.clone(),
+                EnvVar {
+                    name: env_name,
+                    value: Some(real_val),
+                    ..Default::default()
+                },
+            );
         }
 
         let envs = envs.into_values().collect();
@@ -299,6 +385,7 @@ pub struct McpTemplateCreate {
     pub command: Vec<String>,
     pub args: Vec<String>,
     pub envs: HashMap<String, String>,
+    pub arg_envs: HashMap<String, String>,
     pub secret_envs: Vec<String>,
     pub resource_limit_name: String,
     pub authorization_name: String,
@@ -331,6 +418,13 @@ impl McpTemplateStore {
     ) -> Result<McpTemplateData, AppError> {
         let name = encode_k8sname(RESOURCE_TYPE_PREFIX_MCP_TEMPLATE, name);
         let api = self.api();
+        // 검증
+        for (arg_key, arg_val) in &data.arg_envs {
+            assert_valid_arg_env_key(arg_key)?;
+            assert_valid_arg_env_value(arg_key, arg_val)?;
+        }
+
+        //
         let resource_limit_store =
             ResourceLimitStore::new(self.client.clone(), self.default_namespace.clone());
 
@@ -349,7 +443,8 @@ impl McpTemplateStore {
             &data.secret_mounts,
         )
         .await?;
-        let store_authorization = AuthorizationStore::new(self.client.clone(), self.target_namespace.clone());
+        let store_authorization =
+            AuthorizationStore::new(self.client.clone(), self.target_namespace.clone());
         let _authorization = store_authorization
             .get(&data.authorization_name)
             .await?
@@ -399,6 +494,11 @@ impl McpTemplateStore {
                     data.envs
                         .iter()
                         .map(|(key, value)| (data_env_var(key), value.clone())),
+                )
+                .chain(
+                    data.arg_envs
+                        .iter()
+                        .map(|(key, value)| (data_arg_env_var(key), value.clone())),
                 )
                 .collect(),
             ),

--- a/protobuf/mcp_template.proto
+++ b/protobuf/mcp_template.proto
@@ -12,6 +12,7 @@ message CreateMcpTemplateRequest {
   repeated string command = 5;
   repeated string args = 6;
   map<string, string> envs = 7;
+  map<string, string> arg_envs = 13;
   repeated string secret_envs = 8;
   string resource_limit_name = 9;
   optional string authorization_name = 12;
@@ -55,6 +56,7 @@ message McpTemplateResponse {
   repeated string command = 5;
   repeated string args = 6;
   map<string, string> envs = 7;
+  map<string, string> arg_envs = 15;
   repeated string secret_envs = 8;
   string resource_limit_name = 9;
   string authorization_name = 14;


### PR DESCRIPTION
## Summary
- Add support for argument environment variables (arg_envs) in MCP templates
- Implement frontend UI for managing arg_envs with validation
- Add MCP configuration copy functionality with Authorization header support
- Update templates to support dynamic arguments passed via HTTP headers

## Changes

### Backend
- Add `arg_envs` field to MCP template proto (mcp_template.proto:13, 59)
- Implement arg_env validation using regex patterns in template storage
- Support environment variable mapping: HTTP header `arg-{key}` → Pod env `{env_name}={value}`
- Update MCP server instantiation to inject arg_envs into Pod containers

### Frontend
- Add `CopyConfigDialog` component for displaying and copying MCP configurations
- Implement arg_env form fields with validation:
  - Key: must start with lowercase letter (a-z), followed by a-z, 0-9, -
  - ENV_NAME: optional, supports A-Z, a-z, 0-9, _, -
  - Type: dropdown with "string" and "string?" options
- Add "📋 Copy Config" buttons to template list and detail pages
- Automatic Authorization header inclusion for KUBERNETES_SERVICE_ACCOUNT type
- Real-time validation and preview of generated values

### UI Features
- Modal dialog for MCP configuration with clipboard copy
- Inline validation errors for arg_env fields
- Live preview showing HTTP header → Pod Env mapping
- Support for optional/nullable types (string?)

## Technical Details

### Validation Rules
- **arg_env key**: `^[a-z][a-z0-9-]*$`
- **arg_env value**: `^((?<ENV_NAME>[A-Za-z0-9_-]+)\s*:\s*)?(?<TYPENAME>[a-z][a-z0-9-]*\??)$`
- **ENV_NAME**: `[A-Za-z0-9_-]+`
- **TYPE**: `[a-z][a-z0-9-]*` with optional `?` suffix

### MCP Configuration Example
```json
{
  "mcpServers": {
    "template-name": {
      "type": "remote",
      "url": "http://localhost:8080/mcp/namespace/template-name",
      "headers": {
        "arg-proxy-url": "value",
        "arg-timeout": "value" or null,
        "Authorization": "Bearer <token>"
      }
    }
  }
}
```

## Files Changed
- Backend: 4 files (+165 lines)
- Frontend: 7 files (+739 lines)
- Protobuf: 1 file (+2 lines)
- Styles: 1 file (+34 lines)

Total: 14 files changed, 904 insertions(+), 20 deletions(-)